### PR TITLE
Added the missing `normalizeColor` import

### DIFF
--- a/src/standardizeShapes.js
+++ b/src/standardizeShapes.js
@@ -1,3 +1,5 @@
+import normalizeColor from "./normalizeColor.js";
+
 const shapeOrSketch = (shape) => {
   if (!(shape instanceof replicad.Sketch)) return shape;
   if (shape.wire.isClosed) return shape.face();


### PR DESCRIPTION
Hey,
Lovely work with Replicad! 

I've tried the CLI today to generate SVG previews and it fails if parts have color defined

```sh
error: Uncaught ReferenceError: normalizeColor is not defined
    const normalizedColor = color && normalizeColor(color);
                            ^
    at https://deno.land/x/replicad_cli@v1.0.0/src/standardizeShapes.js:33:29
    at Array.map (<anonymous>)
    at normalizeColorAndOpacity (https://deno.land/x/replicad_cli@v1.0.0/src/standardizeShapes.js:30:17)
    at standardizeShapes (https://deno.land/x/replicad_cli@v1.0.0/src/standardizeShapes.js:48:10)
    at Object.buildShapesFromCode (https://deno.land/x/replicad_cli@v1.0.0/src/builder.js:114:10)
    at eventLoopTick (ext:core/01_core.js:175:7)
    at async Command.actionHandler (https://deno.land/x/replicad_cli@v1.0.0/main.js:29:20)
    at async Command.execute (https://deno.land/x/cliffy@v1.0.0-rc.4/command/command.ts:1937:7)
    at async Command.parseCommand (https://deno.land/x/cliffy@v1.0.0-rc.4/command/command.ts:1769:14)
    at async https://deno.land/x/replicad_cli@v1.0.0/main.js:17:1
```

It seems it is only missing the `normalizeColor` method here:
https://github.com/sgenoud/replicad-cli/blob/5b6540cac442f05879fd54b7308e1af2c34756e1/src/standardizeShapes.js#L33

Hope this helps, cheers!